### PR TITLE
feat(ui): add game creation and start functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ If Spencer ever asks you to "make a note" of something, he's probably asking you
 
 ### Convex development notes
 
-- After creating or modifying schema files in `convex/`, run `npx convex dev --once` to generate TypeScript types and API definitions
+- After creating or modifying schema files or adding new queries/mutations in `convex/`, run `npx convex dev --once` to generate TypeScript types and API definitions
 - The generated files in `convex/_generated/` are required for proper TypeScript support in React components
 - Without running this command, `api.queries.functionName` will show TypeScript errors
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as mutations from "../mutations.js";
 import type * as queries from "../queries.js";
 
 /**
@@ -24,6 +25,7 @@ import type * as queries from "../queries.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  mutations: typeof mutations;
   queries: typeof queries;
 }>;
 export declare const api: FilterApi<

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -1,0 +1,71 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const createGame = mutation({
+  args: {},
+  handler: async (ctx) => {
+    // Create a game with default settings
+    const gameId = await ctx.db.insert("games", {
+      status: "waiting",
+      totalRounds: 5,
+      roundDurationMs: 10000, // 10 seconds
+      currentRoundIndex: 0,
+      players: [],
+      roundHistory: [],
+    });
+    
+    return gameId;
+  },
+});
+
+export const startGame = mutation({
+  args: {
+    gameId: v.id("games"),
+  },
+  handler: async (ctx, { gameId }) => {
+    const game = await ctx.db.get(gameId);
+    if (!game) {
+      throw new Error("Game not found");
+    }
+    
+    if (game.status !== "waiting") {
+      throw new Error("Game is not in waiting status");
+    }
+    
+    // Check if there's already a current round for this game
+    const existingRound = await ctx.db
+      .query("currentRounds")
+      .withIndex("by_gameId", (q) => q.eq("gameId", gameId))
+      .first();
+    
+    if (existingRound) {
+      throw new Error("Game already has an active round");
+    }
+    
+    // Get a random question
+    const questions = await ctx.db.query("questions").collect();
+    if (questions.length === 0) {
+      throw new Error("No questions available to start the game");
+    }
+    
+    const randomQuestion = questions[Math.floor(Math.random() * questions.length)];
+    
+    // Create the current round
+    const now = Date.now();
+    const roundId = await ctx.db.insert("currentRounds", {
+      gameId,
+      questionId: randomQuestion._id,
+      startedAt: now,
+      endsAt: now + game.roundDurationMs,
+      playerBets: {},
+      isRevealed: false,
+    });
+    
+    // Update game status to active
+    await ctx.db.patch(gameId, {
+      status: "active",
+    });
+    
+    return roundId;
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,31 @@
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "../convex/_generated/api";
+import { Id } from "../convex/_generated/dataModel";
 import "./App.css";
 
 function App() {
   const games = useQuery(api.queries.getAllGames);
   const currentRounds = useQuery(api.queries.getAllCurrentRounds);
   const questions = useQuery(api.queries.getAllQuestions);
+  
+  const createGame = useMutation(api.mutations.createGame);
+  const startGame = useMutation(api.mutations.startGame);
+
+  const handleCreateGame = async () => {
+    try {
+      await createGame();
+    } catch (error) {
+      alert("Failed to create game: " + error);
+    }
+  };
+
+  const handleStartGame = async (gameId: Id<"games">) => {
+    try {
+      await startGame({ gameId });
+    } catch (error) {
+      alert("Failed to start game: " + error);
+    }
+  };
 
   if (games === undefined || currentRounds === undefined || questions === undefined) {
     return <div>Loading...</div>;
@@ -17,6 +37,12 @@ function App() {
 
       <section>
         <h2>Games ({games.length})</h2>
+        <button 
+          onClick={handleCreateGame}
+          style={{ marginBottom: "20px", padding: "10px 20px", fontSize: "16px" }}
+        >
+          Create New Game
+        </button>
         {games.length === 0 ? (
           <p>No games found</p>
         ) : (
@@ -29,6 +55,14 @@ function App() {
                 <p>Duration: {game.roundDurationMs}ms</p>
                 <p>Players: {game.players.map(p => p.displayName).join(", ")}</p>
                 {game.finishedAt && <p>Finished: {new Date(game.finishedAt).toLocaleString()}</p>}
+                {game.status === "waiting" && (
+                  <button 
+                    onClick={() => handleStartGame(game._id)}
+                    style={{ padding: "8px 16px", marginTop: "10px", backgroundColor: "#007bff", color: "white", border: "none", borderRadius: "4px", cursor: "pointer" }}
+                  >
+                    Start Game
+                  </button>
+                )}
                 <details>
                   <summary>Round History ({game.roundHistory.length})</summary>
                   {game.roundHistory.map((round) => (


### PR DESCRIPTION
- Add createGame mutation to create games with default settings (5 rounds, 10s duration)
- Add startGame mutation to create current round and activate waiting games
- Add "Create New Game" button to UI for easy game creation
- Add "Start Game" button that appears for games in waiting status
- Update CLAUDE.md to clarify when to run npx convex dev --once
- Properly handle TypeScript types for game IDs
